### PR TITLE
Fix issue #88: Incorporate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request fixes #88.

This PR successfully implements automatic package dependency updates using Dependabot. A .github/dependabot.yml file was created with the following configuration: Dependabot is set to check for pip package updates on a weekly basis, with a limit of 10 open pull requests at a time. This setup will help keep our dependencies up-to-date with minimal manual intervention. As this change doesn't involve application code, no additional testing was required.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌